### PR TITLE
Various fixes for channel overlay viewer

### DIFF
--- a/templates/webtest/demo_viewers/channel_overlay_viewer.html
+++ b/templates/webtest/demo_viewers/channel_overlay_viewer.html
@@ -146,19 +146,19 @@ $(document).ready(function() {
         });
         
         $(".cSelect[name='red']").each(function() {
-            if ($(this).attr('checked')) {
+            if ($(this).is(':checked')) {
                 var i=$(this).val();
                 query += '&red='+i;
             };
         });
         $(".cSelect[name='green']").each(function() {
-            if ($(this).attr('checked')) {
+            if ($(this).is(':checked')) {
                 var i=$(this).val();
                 query += '&green='+i;
             };
         });
         $(".cSelect[name='blue']").each(function() {
-            if ($(this).attr('checked')) {
+            if ($(this).is(':checked')) {
                 var i=$(this).val();
                 query += '&blue='+i;
             };

--- a/templates/webtest/demo_viewers/channel_overlay_viewer.html
+++ b/templates/webtest/demo_viewers/channel_overlay_viewer.html
@@ -221,16 +221,8 @@ $(document).ready(function() {
         <img id='viewer' src="" width="{{ image.width }}" height="{{ image.height }}"/>
     </div>
     
-    <div id="preview" style="float:left; width: 100px; height: 100px; overflow: hidden;">
-        <img id="lens" src="" style="width: 100px; height: 100px;" />
-    </div>
-    
     <div style="padding:10px; margin:10px; float:left">
-        <div style="float:right">
-                Zoom: <input id='zoomSelect' type="text" size="5" name="zoom" value='200'/> %
-        </div>
         Adjust the x-shift and y-shift of individual planes to align them. <br />
-        Draw a rectangle on the image to zoom that region.<br />
         Also possible to pick the Z, C, T and Image-ID to mix planes from different images.
         <hr />
         <!-- table of all the channels -->
@@ -293,6 +285,13 @@ $(document).ready(function() {
             </tr>
         </table>
         <hr />
+
+        Lens: draw a rectangle on the main image above to zoom that region.<br />
+        Zoom: <input id='zoomSelect' type="text" size="5" name="zoom" value='200'/> %<br>
+
+        <div id="preview" style="float:left; width: 100px; height: 100px; overflow: hidden;">
+            <img id="lens" src="" style="width: 100px; height: 100px;" />
+        </div>
         
     </div>
 

--- a/templates/webtest/demo_viewers/channel_overlay_viewer.html
+++ b/templates/webtest/demo_viewers/channel_overlay_viewer.html
@@ -20,12 +20,14 @@ $(document).ready(function() {
     var $viewer = $('#viewer');
     var imgHeight = $viewer.attr('height');
     var imgWidth = $viewer.attr('width');
+    var SIZEZ = {{ image.getSizeZ }};
+    var SIZET = {{ image.getSizeT }};
     
     function preview(img, selection) {
         if (!selection.width || !selection.height)
             return;
 
-        var zoomPercent = parseInt($zoomSelect.attr('value'));
+        var zoomPercent = parseInt($zoomSelect.val());
         var height = {{ image.getSizeY }} * zoomPercent/100;
         var width = {{ image.getSizeX }} * zoomPercent/100;
 
@@ -57,7 +59,7 @@ $(document).ready(function() {
     $(".cSelect").click(function() {
         
         var $radio = $(this);
-        var cIndex = $radio.attr('value');
+        var cIndex = $radio.val();
         
         $(".planeRow").css("background", "white")
             .each(function() {
@@ -81,9 +83,9 @@ $(document).ready(function() {
         else if (incType == "plusSmall") incValue = 1;
         
         var $input = $(this).parent().children('input');
-        var oldVal = parseInt($input.attr('value'));
+        var oldVal = parseInt($input.val());
         var newVal = oldVal + incValue;
-        $input.attr('value', newVal);
+        $input.val(newVal);
         refreshImage();
     });
     // increment Z indexes
@@ -95,8 +97,11 @@ $(document).ready(function() {
         // increment all Z indexes
         $('.zIndex').each(function() {
             var $input = $(this);
-            var oldVal = parseInt($input.attr('value'));
-            $input.attr('value', oldVal + incValue);
+            var oldVal = parseInt($input.val());
+            var newVal = oldVal + incValue;
+            if (newVal > -1 && newVal < SIZEZ) {
+                $input.val(oldVal + incValue);
+            }
         });
         refreshImage();
     });
@@ -109,8 +114,11 @@ $(document).ready(function() {
         // increment all Z indexes
         $('.tIndex').each(function() {
             var $input = $(this);
-            var oldVal = parseInt($input.attr('value'));
-            $input.attr('value', oldVal + incValue);
+            var oldVal = parseInt($input.val());
+            var newVal = oldVal + incValue;
+            if (newVal > -1 && newVal < SIZET) {
+                $input.val(oldVal + incValue);
+            }
         });
         refreshImage();
     });
@@ -126,32 +134,32 @@ $(document).ready(function() {
             if (index>0){
                 query += ",";
             }
-            var imageId = $row.find('[name="imageId"]').attr('value');
-            var z = $row.find('[name="z"]').attr('value');
-            var c = $row.find('[name="c"]').attr('value');
-            var t = $row.find('[name="t"]').attr('value');
+            var imageId = $row.find('[name="imageId"]').val();
+            var z = $row.find('[name="z"]').val();
+            var c = $row.find('[name="c"]').val();
+            var t = $row.find('[name="t"]').val();
             query += index + "|" + imageId + ":" + z  + ":" + c + ":" + t;
-            var x = $row.find('[name="x"]').attr('value');
-            var y = $row.find('[name="y"]').attr('value');
+            var x = $row.find('[name="x"]').val();
+            var y = $row.find('[name="y"]').val();
             query += "$x:" + x + "_y:" + y;
             index +=1;
         });
         
         $(".cSelect[name='red']").each(function() {
             if ($(this).attr('checked')) {
-                var i=$(this).attr('value');
+                var i=$(this).val();
                 query += '&red='+i;
             };
         });
         $(".cSelect[name='green']").each(function() {
             if ($(this).attr('checked')) {
-                var i=$(this).attr('value');
+                var i=$(this).val();
                 query += '&green='+i;
             };
         });
         $(".cSelect[name='blue']").each(function() {
             if ($(this).attr('checked')) {
-                var i=$(this).attr('value');
+                var i=$(this).val();
                 query += '&blue='+i;
             };
         });
@@ -178,12 +186,12 @@ $(document).ready(function() {
         var imageId = null;
         $(".planeRow").each(function() {
             var $row = $(this);
-            imageId = $row.find('[name="imageId"]').attr('value');
-            var z = $row.find('[name="z"]').attr('value');
+            imageId = $row.find('[name="imageId"]').val();
+            var z = $row.find('[name="z"]').val();
             zOffsets.push(z);
-            var x = $row.find('[name="x"]').attr('value');
+            var x = $row.find('[name="x"]').val();
             xOffsets.push(x);
-            var y = $row.find('[name="y"]').attr('value');
+            var y = $row.find('[name="y"]').val();
             yOffsets.push(y);
         });
         // normalise z-offsets to 0

--- a/urls.py
+++ b/urls.py
@@ -55,7 +55,7 @@ urlpatterns = patterns(
     # Viewer overlays individual channels from the same image or
     # different images and manipulate them separately.
     # Translate, scale etc relative to one-another.
-    url(r'^channel_overlay_viewer/(?P<imageId>[0-9]+)/',
+    url(r'^channel_overlay_viewer/(?P<iid>[0-9]+)/',
         views.channel_overlay_viewer, name='webtest_channel_overlay_viewer'),
     # this is the url for rendering planes for the viewer
     url(r'^render_channel_overlay/', views.render_channel_overlay,

--- a/views.py
+++ b/views.py
@@ -91,7 +91,8 @@ def channel_overlay_viewer(request, iid, conn=None, **kwargs):
 
     if image is not None:
         if image.getSizeC() == 1:
-            return HttpResponseRedirect(reverse("webgateway.views.full_viewer", args=(iid,)))
+            return HttpResponseRedirect(
+                reverse("webgateway.views.full_viewer", args=(iid,)))
 
     # try to work out which channels should be 'red',
     # 'green', 'blue' based on rendering settings
@@ -373,8 +374,8 @@ def split_view_figure(request, conn=None, **kwargs):
             # if we have channel info from a form, we know that
             # checkbox:None is unchecked (not absent)
             if request.REQUEST.get('cName%s' % i, None):
-                active = (None != request.REQUEST.get('cActive%s' % i, None))
-                merged = (None != request.REQUEST.get('cMerged%s' % i, None))
+                active = request.REQUEST.get('cActive%s' % i, None) is not None
+                merged = request.REQUEST.get('cMerged%s' % i, None) is not None
             else:
                 active = True
                 merged = True
@@ -490,7 +491,7 @@ def dataset_split_view(request, datasetId, conn=None, **kwargs):
             if request.REQUEST.get('cStart%s' % i, None):
                 active_left = (None is not request.REQUEST.get(
                                'cActiveLeft%s' % i, None))
-                active_right = (None != request.REQUEST.get(
+                active_right = (None is not request.REQUEST.get(
                                 'cActiveRight%s' % i, None))
             else:
                 active_left = True

--- a/views.py
+++ b/views.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
-from django.http import HttpResponse
+from django.http import HttpResponse, HttpResponseRedirect
 from django.shortcuts import render
 from django.views import generic
 from django.core.urlresolvers import reverse
@@ -80,14 +80,18 @@ def index(request, conn=None, **kwargs):
 
 
 @login_required()
-def channel_overlay_viewer(request, imageId, conn=None, **kwargs):
+def channel_overlay_viewer(request, iid, conn=None, **kwargs):
     """
     Viewer for overlaying separate channels from the same image or
     different images and adjusting horizontal and vertical alignment
     of each
     """
-    image = conn.getObject("Image", imageId)
+    image = conn.getObject("Image", iid)
     default_z = image.getSizeZ()/2
+
+    if image is not None:
+        if image.getSizeC() == 1:
+            return HttpResponseRedirect(reverse("webgateway.views.full_viewer", args=(iid,)))
 
     # try to work out which channels should be 'red',
     # 'green', 'blue' based on rendering settings
@@ -159,7 +163,7 @@ def render_channel_overlay(request, conn=None, **kwargs):
     # e.g. planes=0|2305:7:0:0$x:-50_y:10,1|2305:7:1:0,2|2305:7:2:0\
     #      &red=2&blue=0&green=1
     planes = {}
-    p = request.REQUEST.get('planes', None)
+    p = request.GET.get('planes', None)
     if p is None:
         return HttpResponse("Request needs plane info to render jpeg e.g.\
             ?planes=0|2305:7:0:0$x:-50_y:10,1|2305:7:1:0,2|2305:7:2:0\
@@ -185,9 +189,9 @@ def render_channel_overlay(request, conn=None, **kwargs):
 
     # from the request we need to know which plane is blue,
     # green, red (if any) by index e.g. red=0&green=2
-    red = request.REQUEST.get('red', None)
-    green = request.REQUEST.get('green', None)
-    blue = request.REQUEST.get('blue', None)
+    red = request.GET.get('red', None)
+    green = request.GET.get('green', None)
+    blue = request.GET.get('blue', None)
 
     # like split-view: we want to get single-channel images...
 
@@ -257,7 +261,7 @@ def render_channel_overlay(request, conn=None, **kwargs):
     merge.save(rv, 'jpeg', quality=int(compression*100))
     jpeg_data = rv.getvalue()
 
-    rsp = HttpResponse(jpeg_data, mimetype='image/jpeg')
+    rsp = HttpResponse(jpeg_data, content_type='image/jpeg')
     return rsp
 
 


### PR DESCRIPTION
Fixed and improved a few issues with the channel_overlay_viewer noticed while using it as an example for docs PR at https://github.com/openmicroscopy/ome-documentation/pull/1406

 To test:
- Choose an image and go to `/webtest/channel_overlay_viewer/<imageId>/`
- Check that image is shown in viewer page
- Use the x-shift and y-shift + and - buttons to shift channels up, down, left, right
- Use the Z and T + and - buttons to increment Z and T indices - shouldn't go out of bounds
- If a single channel image is opened, should redirect to webgateway image viewer.
- Also fixed deprecation warnings for request.REQUEST.
