### PR TITLE
plate_viewer example

### DIFF
--- a/omero_webtest/templates/webtest/examples/plate_viewer.html
+++ b/omero_webtest/templates/webtest/examples/plate_viewer.html
@@ -1,0 +1,39 @@
+<!DOCTYPE html>
+<html>
+    <head>
+        <title>
+            OMERO.web - embed plate viewer
+        </title>
+
+        <style type="text/css">
+
+        </style>
+        
+        {% include "webgateway/base/includes/script_src_jquery.html" %}
+
+        <script type="text/javascript" src="{{ host_name }}static/webgateway/js/ome.gs_utils.js"></script>
+        <script type="text/javascript" src="{{ host_name }}static/webgateway/js/ome.plateview.js"></script>
+
+        <script type="text/javascript">
+   
+            $(document).ready(function () {
+
+                console.log("{{ host_name }}".slice(0, -1));
+
+                var plate_id = {{ image_id }};
+
+                var wpv = $.WeblitzPlateview($('#spw'), {baseurl: '{{ host_name }}webgateway',
+                                                     width: 96,
+                                                     staticurl: "{{ host_name }}static/webgateway/",
+                                                     useParentPrefix: false});
+                 wpv.load(plate_id, 0);
+            });
+        </script>
+
+    </head>
+<body>
+
+    <div id="spw"></div>
+
+</body>
+</html>

--- a/omero_webtest/templates/webtest/examples/plate_viewer.html
+++ b/omero_webtest/templates/webtest/examples/plate_viewer.html
@@ -8,6 +8,8 @@
         <style type="text/css">
 
         </style>
+
+        <link rel="stylesheet" type="text/css" href="{{ host_name }}static/webgateway/css/ome.plateview.css">
         
         {% include "webgateway/base/includes/script_src_jquery.html" %}
 


### PR DESCRIPTION
Adds a static example using the ```WeblitzPlateview``` plugin to load and display a Plate of data.
See https://trello.com/c/rjvcPeUH/300-breaking-omero-web-unnecessarily

To test: use a ``` plate_id ``` in this URL:

```/webtest/examples/{plate_id}/plate_viewer.html```
This should load the plate and show Wells with thumbnails.

Happy to discuss whether we need to add anything more or if this is sufficient to demonstrate that the plugin is working?

cc @aleksandra-tarkowska 