### PR TITLE
webgateway_full_viewer_named_URL

### DIFF
--- a/omero_webtest/views.py
+++ b/omero_webtest/views.py
@@ -92,7 +92,7 @@ def channel_overlay_viewer(request, iid, conn=None, **kwargs):
     if image is not None:
         if image.getSizeC() == 1:
             return HttpResponseRedirect(
-                reverse("webgateway.views.full_viewer", args=(iid,)))
+                reverse("webgateway_full_viewer", args=(iid,)))
 
     # try to work out which channels should be 'red',
     # 'green', 'blue' based on rendering settings


### PR DESCRIPTION
Use name 'webgateway_full_viewer' for reverse() to work with omero-web since we now need to use names rather than "path.to.views.method"

See https://github.com/ome/omero-web/pull/10/commits/2fff52d8dabfb0087493a1f2dc7068594912d1c4
